### PR TITLE
Use time-locale-compat to avoid CPP

### DIFF
--- a/Control/Logging.hs
+++ b/Control/Logging.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
-{-# LANGUAGE CPP #-}
 
 -- | Quick example of how to use this module:
 --
@@ -73,9 +72,7 @@ import Data.Monoid
 import Data.Text as T
 import Data.Text.Encoding as T
 import Data.Time
-#if !MIN_VERSION_time (1,5,0)
-import System.Locale (defaultTimeLocale)
-#endif
+import Data.Time.Locale.Compat (defaultTimeLocale)
 import Debug.Trace
 import Prelude hiding (log)
 import System.IO.Unsafe

--- a/logging.cabal
+++ b/logging.cabal
@@ -44,6 +44,7 @@ Library
       , time                 >= 1.4
       , monad-control        >= 0.3.2.3
       , text                 >= 0.11.3.1
+      , time-locale-compat   >= 0.1.1.0
       , transformers         >= 0.3.0.0
       , lifted-base          >= 0.2.2.0
       , pcre-light           >= 0.4


### PR DESCRIPTION
I perpetrated it initially, but there's a better strategy, I think.
