### PR TITLE
Replaced `pcre-light` with `regex-compat` for better Windows experience

### DIFF
--- a/logging.cabal
+++ b/logging.cabal
@@ -47,7 +47,7 @@ Library
       , time-locale-compat   >= 0.1.1.0
       , transformers         >= 0.3.0.0
       , lifted-base          >= 0.2.2.0
-      , pcre-light           >= 0.4
+      , regex-compat         >= 0.95.1
     exposed-modules:
         Control.Logging
     default-extensions:


### PR DESCRIPTION
Getting `pcre-light` to work on Windows is a pain (didn't get it to work within 5 minutes), whereas `regex-compat` works out of the box.

The changes aren't a net win, though.
1. `regex-compat` uses `String` and is probably inferior performance-wise
2. This might introduce breaking changes in the way regexes are processed

Regarding the former, I could change the code to using `text-icu` instead if you wish so, although I don't think that performance matters when filtering debug log messages.
